### PR TITLE
✔️ Fix link to window object in jsdom

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
 import jsdom from 'jsdom';
 
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
+global.window = document.defaultView;


### PR DESCRIPTION
[From off repo](https://github.com/tmpvar/jsdom#creating-a-browser-like-window-object):

``` js
var jsdom = require("jsdom").jsdom;
var document = jsdom("hello world");
var window = document.defaultView;
```
